### PR TITLE
Update the circle position when the frame was updated

### DIFF
--- a/Sources/RangeMap/RangeMap.swift
+++ b/Sources/RangeMap/RangeMap.swift
@@ -68,6 +68,10 @@ public class RangeMap: UIView {
         
         NSLayoutConstraint.activate(constraints)
     }
+    
+    public override func layoutSubviews() {
+        updateCircle()
+    }
 }
 
 private extension RangeMap {


### PR DESCRIPTION
Related: #2 

Although the frame was updated, the circle position wasn't be updated.
Added `updateCircle` inside `layoutSubviews` to calculate the new position based on the new frame to fix this issue. 